### PR TITLE
set setMinDate back to its original state

### DIFF
--- a/src/components/Reservation.js
+++ b/src/components/Reservation.js
@@ -222,7 +222,7 @@ function Reservation() {
     }
   };
 
-  // Closes the reservation and confirmation popups and resets input fields to their initial state.
+  // resets input fields to their initial state and
   const handleCloseSubmit = () => {
     if (confirmationPopup) {
       setName('');
@@ -231,7 +231,7 @@ function Reservation() {
       setPickDate('');
       setTime('');
       setGuests('');
-      setMinDate('');
+      setMinDate(new Date().toISOString().split('T')[0]);
       setConfirmationPopup(false);
     }
   };


### PR DESCRIPTION
saw a bug after reservation confirmation was closed, setMinDate was set back to a string instead of   
new Date().toISOString().split('T')[0]

preventing it from keeping previous dates on the calendar unavailable to users